### PR TITLE
Endpoint get turns

### DIFF
--- a/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/SecurityConfiguration.kt
+++ b/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/SecurityConfiguration.kt
@@ -1,0 +1,19 @@
+package ARBeautyandMakeupbackend.ARBeautyandMakeupbackend
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+
+
+@EnableWebSecurity
+class SecurityConfiguration : WebSecurityConfigurerAdapter() {
+
+    @Override
+    override fun configure(http: HttpSecurity?) {
+        http!!.authorizeRequests()
+                .antMatchers("/**")
+                .permitAll().and()
+                .formLogin()
+
+    }
+}

--- a/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/controllers/TurnController.kt
+++ b/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/controllers/TurnController.kt
@@ -1,0 +1,29 @@
+package ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.controllers
+
+import ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.model.Turn
+import ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.services.TurnService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.CrossOrigin
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@EnableAutoConfiguration
+@CrossOrigin(origins = ["*"], allowedHeaders = ["*"])
+class TurnController {
+
+    @Autowired
+    lateinit var turnService: TurnService
+
+    @GetMapping("/turns")
+    fun getTurns(): ResponseEntity<List<Turn>> {
+
+        val turns = turnService.getTurns()
+        val response = ResponseEntity.status(HttpStatus.OK).body(turns)
+
+        return response
+    }
+}

--- a/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/controllers/TurnController.kt
+++ b/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/controllers/TurnController.kt
@@ -4,11 +4,11 @@ import ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.model.Turn
 import ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.services.TurnService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
 
 @RestController
 @EnableAutoConfiguration
@@ -22,6 +22,14 @@ class TurnController {
     fun getTurns(): ResponseEntity<List<Turn>> {
 
         val turns = turnService.getTurns()
+        val response = ResponseEntity.status(HttpStatus.OK).body(turns)
+
+        return response
+    }
+
+    @GetMapping("/turns/{date}")
+    fun getTurnsByDate(@PathVariable("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate): ResponseEntity<List<Turn>> {
+        val turns = turnService.findAllByDate(date)
         val response = ResponseEntity.status(HttpStatus.OK).body(turns)
 
         return response

--- a/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/persistence/TurnRepository.kt
+++ b/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/persistence/TurnRepository.kt
@@ -4,6 +4,7 @@ import ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.model.Turn
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Repository
@@ -11,7 +12,7 @@ interface TurnRepository : JpaRepository<Turn, Long>{
 
 
     @Query(value = "SELECT * FROM TURN turn WHERE YEAR(turn.DATE) = YEAR(:date) AND MONTH(turn.DATE) = MONTH(:date) AND DAY(turn.DATE) = DAY(:date)", nativeQuery = true)
-    fun findAllByDate(date: LocalDateTime): List<Turn>
+    fun findAllByDate(date: LocalDate): List<Turn>
 
 
 }

--- a/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/services/ITurnService.kt
+++ b/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/services/ITurnService.kt
@@ -1,12 +1,12 @@
 package ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.services
 
 import ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.model.Turn
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 interface ITurnService {
 
     fun getTurns(): List<Turn>
     fun addTurn(aTurn: Turn): Turn
     fun find(id: Long): Turn
-    fun findAllByDate(date: LocalDateTime): List<Turn>
+    fun findAllByDate(date: LocalDate): List<Turn>
 }

--- a/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/services/TurnService.kt
+++ b/src/main/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/services/TurnService.kt
@@ -4,6 +4,7 @@ import ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.model.Turn
 import ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.persistence.TurnRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Service
@@ -24,7 +25,7 @@ class TurnService : ITurnService{
         return turnRepository.findById(id).get()
     }
 
-    override fun findAllByDate(date: LocalDateTime): List<Turn> {
+    override fun findAllByDate(date: LocalDate): List<Turn> {
         return turnRepository.findAllByDate(date)
     }
 }

--- a/src/test/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/controllers/TurnControllerTest.kt
+++ b/src/test/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/controllers/TurnControllerTest.kt
@@ -36,13 +36,5 @@ class TurnControllerTest {
             .andExpect(MockMvcResultMatchers.status().isOk)
     }
 
-    @Test
-    fun ifWeAskForTurnsWithASpeceificDateWeGetTheAllTurnsWithThatDate(){
-        var date =LocalDateTime.of(2021, 4, 20, 16, 0)
-        var turnsWithDate = TurnBuilder.turnListBySameDate(date)
-        `when`(turnServiceMock.getTurns()).thenReturn(turnsWithDate)
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/turns/{date}"))
-            .andExpect(MockMvcResultMatchers.status().isOk)
-    }
 }

--- a/src/test/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/controllers/TurnControllerTest.kt
+++ b/src/test/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/controllers/TurnControllerTest.kt
@@ -13,6 +13,7 @@ import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.time.LocalDateTime
 
 
 @SpringBootTest
@@ -35,4 +36,13 @@ class TurnControllerTest {
             .andExpect(MockMvcResultMatchers.status().isOk)
     }
 
+    @Test
+    fun ifWeAskForTurnsWithASpeceificDateWeGetTheAllTurnsWithThatDate(){
+        var date =LocalDateTime.of(2021, 4, 20, 16, 0)
+        var turnsWithDate = TurnBuilder.turnListBySameDate(date)
+        `when`(turnServiceMock.getTurns()).thenReturn(turnsWithDate)
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/turns/{date}"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+    }
 }

--- a/src/test/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/controllers/TurnControllerTest.kt
+++ b/src/test/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/controllers/TurnControllerTest.kt
@@ -1,0 +1,38 @@
+package ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.controllers
+
+import ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.builders.TurnBuilder
+import ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.services.TurnService
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+
+@SpringBootTest
+@RunWith(SpringRunner::class)
+@AutoConfigureMockMvc
+class TurnControllerTest {
+
+    @MockBean
+    lateinit var turnServiceMock: TurnService
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    fun ifWeAskForTurnsWeGetTheAllTurns(){
+        var allTurns = TurnBuilder.turnList()
+        `when`(turnServiceMock.getTurns()).thenReturn(allTurns)
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/turns"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+    }
+
+}

--- a/src/test/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/repository/TurnRepositoryTest.kt
+++ b/src/test/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/repository/TurnRepositoryTest.kt
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.test.context.junit4.SpringRunner
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @RunWith(SpringRunner::class)
@@ -30,7 +31,7 @@ class TurnRepositoryTest {
 
     @Test
     fun testTurnRepositoryRetrievedAEmptyListWhenWeFindByDate(){
-        Assert.assertEquals(listOf<Turn>(), repository.findAllByDate(LocalDateTime.now()))
+        Assert.assertEquals(listOf<Turn>(), repository.findAllByDate(LocalDate.now()))
     }
 
 
@@ -39,7 +40,7 @@ class TurnRepositoryTest {
         var listTurns = TurnBuilder.turnListBySameDate(LocalDateTime.now())
 
         listTurns.forEach { repository.save(it) }
-        Assert.assertEquals(listTurns.size, repository.findAllByDate(LocalDateTime.now()).size)
+        Assert.assertEquals(listTurns.size, repository.findAllByDate(LocalDate.now()).size)
     }
 
 

--- a/src/test/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/service/TurnServiceTest.kt
+++ b/src/test/kotlin/ARBeautyandMakeupbackend/ARBeautyandMakeupbackend/service/TurnServiceTest.kt
@@ -11,6 +11,7 @@ import ARBeautyandMakeupbackend.ARBeautyandMakeupbackend.services.TurnService
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -52,10 +53,11 @@ class TurnServiceTest {
 
     @Test
     fun whenWeAskTurnServiceForAllTheTurnsByDateReturnAListOfTurn() {
-        var aDate =  LocalDateTime.now()
-        var aListOfTurnByDate = TurnBuilder.turnListBySameDate(aDate)
-        `when`(turnRepositoryMock.findAllByDate(aDate)).thenReturn(aListOfTurnByDate)
+        val aDate =  LocalDateTime.now()
+        val aListOfTurnByDate = TurnBuilder.turnListBySameDate(aDate)
+        val aLocalDate = LocalDate.of(aDate.year, aDate.month, aDate.dayOfMonth)
+        `when`(turnRepositoryMock.findAllByDate(aLocalDate)).thenReturn(aListOfTurnByDate)
 
-        Assert.assertEquals(aListOfTurnByDate.size, turnService.findAllByDate(aDate).size)
+        Assert.assertEquals(aListOfTurnByDate.size, turnService.findAllByDate(aLocalDate).size)
     }
 }


### PR DESCRIPTION
Configuracion de seguridad de springboot. (Lucas)
Endpoint para obtener todos los turnos. (Lucas)
Endpoint para obtener los turnos de una fecha especifica.
Refactor de método en el repository para obtener turnos de una fecha.